### PR TITLE
Python image order

### DIFF
--- a/python_code/main_dpc.ipynb
+++ b/python_code/main_dpc.ipynb
@@ -165,7 +165,7 @@
     "    if plot_row == 0:\n",
     "        plot = ax[plot_row, plot_col].imshow(np.fft.fftshift(dpc_solver_obj.Hu[plot_col].real), cmap='jet',\\\n",
     "                                             extent=[min_na_x, max_na_x, min_na_y, max_na_y], clim=[-2., 2.])\n",
-    "        ax[plot_row, plot_col].set_title(\"Absorptino WOTF {:02d}\".format(plot_col))\n",
+    "        ax[plot_row, plot_col].set_title(\"Absorption WOTF {:02d}\".format(plot_col))\n",
     "        plt.colorbar(plot, cax=cax, ticks=[-2., 0, 2.])\n",
     "    else:\n",
     "        plot = ax[plot_row, plot_col].imshow(np.fft.fftshift(dpc_solver_obj.Hp[plot_col].imag), cmap='jet',\\\n",

--- a/python_code/main_dpc.ipynb
+++ b/python_code/main_dpc.ipynb
@@ -42,6 +42,7 @@
     "data_path  = \"../sample_data/\" #INSERT YOUR DATA PATH HERE\n",
     "image_list = listdir(data_path)\n",
     "image_list = [image_file for image_file in image_list if image_file.endswith(\".tif\")]\n",
+    "image_list.reverse() # re-order so the first one is 'ILED_0001.tif'\n",
     "dpc_images = np.array([io.imread(data_path+image_list[image_index]) for image_index in range(len(image_list))])"
    ]
   },
@@ -235,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The python script was not generating the correct phase-contrast image (see attached image sample)

![old](https://user-images.githubusercontent.com/1529852/54214280-5610e900-44bc-11e9-997a-fe74c2b697a7.png)

![new](https://user-images.githubusercontent.com/1529852/54214289-5c06ca00-44bc-11e9-9c16-1bde4689b210.png)

After a bit of playing around, I found that the loaded images did not correspond to the illumination pattern. It turns out the python script loaded the images in descending order (`ILED_0004.tif`, `ILED_0003.tif`, `ILED_0002.tif`, `ILED_0001.tif` ) whereas the Matlab code loads them in ascending order.

fixes:
- minor typo in plot labels
- image order